### PR TITLE
Added tdb configuration, and *.gz data uploads on init.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ RUN set -eux && \
 RUN mkdir -p $FUSEKI_HOME/extra
 COPY ./lib/jena-kafka-connector-0.0.3-SNAPSHOT.jar ./lib/kafka-clients-2.5.0.jar $FUSEKI_HOME/extra/
 
-COPY ./jetty-config.xml $FUSEKI_HOME
+COPY ./jetty-config.xml $FUSEKI_HOME/
 COPY ./config.ttl.tpl $FUSEKI_HOME/
+COPY ./tdb.cfg.tpl $FUSEKI_HOME/
 
 # fuseki-db-init is our local bash script to initialize databases
 COPY ./fuseki-db-init /usr/local/bin/fuseki-db-init

--- a/fuseki-db-init
+++ b/fuseki-db-init
@@ -248,8 +248,8 @@ function tdb2.graphs() {
 
   for g in "$@"; do
     graph="http://$(urldecode $(basename $g))/"
-    for f in $(find $g -type f -name \*.ttl -o -name \*.n3); do
-        op tdb2.tdbloader --graph="$graph" --desc=$desc $f
+    for f in $(find $g -type f -name \*.ttl -o -name \*.n3 -o -name \*.gz ); do
+        op tdb2.tdbloader --graph="$graph" --loader=parallel --desc=$desc $f
     done
   done
 
@@ -333,7 +333,7 @@ function db.dir() {
   local desc=${G[fuseki]}/configuration/$(ls -1 $db/configuration | head -1)
 
     # Add Graph data
-  [[ -d $db/graph ]] && tdb2.graphs --desc=$desc $(find $db/graph -mindepth 1 -maxdepth 1 -type d)
+  [[ -d $db/graph ]] && tdb2.graphs --desc=$desc $(find $db/graph -mindepth 1 -type d)
   tdb2.updates --desc=$desc $(find $db -type f -name *.sparql-update)
 
 }

--- a/tdb.cfg.tpl
+++ b/tdb.cfg.tpl
@@ -1,0 +1,31 @@
+{
+  "tdb.file_mode" : "mapped" ,
+  "tdb.block_size" : 4096 ,
+  "tdb.block_read_cache_size" : 10000 ,
+  "tdb.block_write_cache_size" : 2000 ,
+  "tdb.node2nodeid_cache_size" : 100000 ,
+  "tdb.nodeid2node_cache_size" : 500000 ,
+  "tdb.node_miss_cache_size" : 100 ,
+  "tdb.index_node2id" : "node2id" ,
+  "tdb.index_id2node" : "nodes" ,
+  "tdb.triple_index_primary" : "SPO" ,
+  "tdb.triple_indexes" : [
+      "SPO" ,
+      "POS" ,
+      "OSP"
+    ] ,
+  "tdb.quad_index_primary" : "GSPO" ,
+  "tdb.quad_indexes" : [
+      "GSPO" ,
+      "GPOS" ,
+      "GOSP" ,
+      "POSG" ,
+      "OSPG" ,
+      "SPOG"
+    ] ,
+  "tdb.prefix_index_primary" : "GPU" ,
+  "tdb.prefix_indexes" : [ "GPU" ] ,
+  "tdb.file_prefix_index" : "prefixIdx" ,
+  "tdb.file_prefix_nodeid" : "prefix2id" ,
+  "tdb.file_prefix_id2node" : "prefixes"
+}


### PR DESCRIPTION
This allows direct inclusion of gzipped files as in the [Material Science](https://gitlab.dams.library.ucdavis.edu/experts/experts-data/tree/material_science) gitlab example.  This also includes a customized tdb.cfg file from @jtyzzer for better performance. 