### PR TITLE
Updated Graph Initialization.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ucdlib/jena-fuseki-eb:jena-3.15.0
 
 RUN set -eux && \
     apt-get update && \
-    apt-get install -y util-linux rsync perl wait-for-it && \
+    apt-get install -y util-linux rsync perl wait-for-it git && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p $FUSEKI_HOME/extra
@@ -14,8 +14,9 @@ COPY ./tdb.cfg.tmpl $FUSEKI_HOME/
 COPY ./shiro.ini.tmpl $FUSEKI_HOME/
 COPY ./configuration $FUSEKI_HOME/configuration/
 COPY ./databases $FUSEKI_HOME/databases/
-COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+COPY ./rp-ucd-fuseki-docker-entrypoint.sh /rp-ucd-fuseki-docker-entrypoint.sh
+COPY ./fuseki-import-graphs /usr/local/bin
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+ENTRYPOINT ["/rp-ucd-fuseki-docker-entrypoint.sh"]
 
 CMD ["/jena-fuseki/fuseki-server", "--jetty-config=/jena-fuseki/jetty-config.xml"]

--- a/build/local-build.sh
+++ b/build/local-build.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-TAG_NAME=1.1.0
+TAG_NAME=1.1.1
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $ROOT_DIR/..

--- a/build/submit-build.sh
+++ b/build/submit-build.sh
@@ -2,7 +2,7 @@
 
 # manually setting this... for now :(
 # TAG_NAME=jena-3.15.0-c-0.0.3
-TAG_NAME=1.1.0
+TAG_NAME=1.1.1
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $ROOT_DIR/..

--- a/config.ttl.tmpl
+++ b/config.ttl.tmpl
@@ -37,5 +37,7 @@
   ucd:kafkaEnabled "${KAFKA_ENABLED:-TRUE}" ;
   ucd:kafkaTopic "${KAFKA_TOPIC:-fuseki-rdf-patch}" ;
   ucd:kafkaHost "${KAFKA_HOST:-kafka}" ;
-  ucd:kafkaPort "${KAFKA_PORT:-3030}"
+  ucd:kafkaPort "${KAFKA_PORT:-3030}" ;
+  ${KAFKA_USERNAME}
+  ${KAFKA_PASSWORD}
   .

--- a/config.ttl.tmpl
+++ b/config.ttl.tmpl
@@ -34,7 +34,7 @@
    .
 
 [] rdf:type ucd:Kafka ;
-  ucd:kafkaEnabled "${KAFKA_ENABLED:-FALSE}" ;
+  ucd:kafkaEnabled "${KAFKA_ENABLED:-TRUE}" ;
   ucd:kafkaTopic "${KAFKA_TOPIC:-fuseki-rdf-patch}" ;
   ucd:kafkaHost "${KAFKA_HOST:-kafka}" ;
   ucd:kafkaPort "${KAFKA_PORT:-3030}"

--- a/fuseki-import-graphs
+++ b/fuseki-import-graphs
@@ -1,0 +1,55 @@
+#! /bin/bash
+
+# Reads the directories passed on the commmand line, and imports
+
+if ! opts=$(getopt -o c: --long clone: -n fuseki-import-graphs -- "$@"); then
+  echo "Bad Command Options." >&2 ; exit 1 ; fi
+
+eval set -- "$opts"
+
+while true; do
+	case $1 in
+    -c | --clone) clone="$2"; shift 2;;
+	  *) shift; break;
+  esac
+done
+
+auth=admin:${FUSEKI_PASSWORD}
+load=http://fuseki:3030/experts_private/data
+
+graphs=(
+  iam.ucdavis.edu
+  oapolicy.universityofcalifornia.edu
+  experts.ucdavis.edu%2Fiam
+  experts.ucdavis.edu%2Foap
+)
+
+import_dir=/fuseki/import
+
+if [[ -n $clone ]]; then
+  [[ -d ${import_dir} ]] || mkdir ${import_dir}
+  clone_dir=$(mktemp -d --tmpdir=$import_dir)
+  echo "fuseki-import-graphs - git clone $clone $clone_dir"
+  git clone $clone $clone_dir;
+
+  # Add to list of diretories
+  set -- "$@" $clone_dir
+fi
+
+names="${graphs[@]/#/ -o -name }"
+names=${names#*-o}
+
+for root in "$@"; do
+  for dir in $(find $root -type d $names); do
+    for fn in $(find ${dir} -type f -name \*.ttl -o -name \*.ttl.gz ); do
+      graph=$(basename $(dirname $fn))
+      echo "fuseki-import-graphs - import $graph"
+      curl --user "${auth}" -F "file=@$fn" "${load}?graph=$(printf 'http://%b/' ${graph//%/\\x})"
+    done
+  done
+done
+
+if [[ -d $clone_dir ]]; then
+  echo "fuseki-import-graphs - rm $clone_dir"
+  rm -rf $clone_dir
+fi

--- a/shiro.ini.tmpl
+++ b/shiro.ini.tmpl
@@ -25,7 +25,7 @@ iniRealm.credentialsMatcher = $plainMatcher
 
 [users]
 # Implicitly adds "iniRealm =  org.apache.shiro.realm.text.IniRealm"
-admin=${ADMIN_PASSWORD:-$(pwgen -s 15)}
+admin=${FUSEKI_PASSWORD:-$(pwgen -s 15)}
 
 [roles]
 


### PR DESCRIPTION
@jrmerz This is an update for the code, to simplify the initialization step for developers, but README has more info, but basically after startup run:

``` bash
docker-compose exec fuseki fuseki-import-graphs --clone="https://quinn:${GITLAB_PUSH_TOKEN}@gitlab.dams.library.ucdavis.edu/experts/experts-data.git --single-branch --branch=experts"
```

However,  I did not get the KAFKA stream to work, and so you need to run the reindexer, I suspect my config is bad, and would like you advice.