### PR TITLE
Added `fuseki-import-graphs --private` to import private graphs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ucdlib/jena-fuseki-eb:jena-3.15.0
 
 RUN set -eux && \
     apt-get update && \
-    apt-get install -y util-linux rsync perl wait-for-it git && \
+    apt-get install -y util-linux rsync perl wait-for-it git git-lfs && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p $FUSEKI_HOME/extra

--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ the others are private.
 ├── oapolicy.universityofcalifornia.edu
 │   └── *.ttl.gz    # These data are VIVO constructed publication data
 │       └── vivo.owl
+├── experts.ucdavis.edu
+│   └── *.ttl.gz    # This goes to the default public database.
 ├── experts.ucdavis.edu%2Foap
-│   └── *.ttl.gz    # This is the raw JSON data from the CDL publication system.
+│   └── *.ttl.gz    # Private data from the CDL publication system.
 └── experts.ucdavis.edu%2Fiam
-    └── *.ttl.gz    # This is raw JSON data from the UCD IAM system.
+    └── *.ttl.gz    # Private data from the UCD IAM system.
 
 ```
 
@@ -119,7 +121,11 @@ docker-compose exec fuseki fuseki-import-graphs /fuseki/import
 In order to utilize the KAFKA stream monitoring, `fuseki-import-graphs`
 requires the fuseki server to be running.
 
-## Github Initializaton
+By default `fuseki-import-graphs` only imports public graphs, however using the
+`--private` flag will import private graphs as well.  This can help decode
+existing conversions from private to public data.
+
+## Github Initialization
 
 Finally, `fuseki-import-graphs` can also clone data from a git repository.  The
 data is cloned into a directory of `/fuseki/import/` which *should* be a docker
@@ -132,7 +138,11 @@ well. The example below shows a typical use for this:
 docker-compose exec fuseki fuseki-import-graphs --clone="https://quinn:${GITLAB_PUSH_TOKEN}@gitlab.dams.library.ucdavis.edu/experts/experts-data.git --single-branch --branch=experts"
 ```
 
-# Special Server initializations
+By default `fuseki-import-graphs` only imports public graphs, however using the
+`--private` flag will import private graphs as well.  This can help decode
+existing conversions from private to public data.
+
+# Special Server Initialization
 
 By default, the server is launched like `/jena-fuseki/fuseki-server
 --jetty-config=/jena-fuseki/jetty-config.xml`  You can modify this in the

--- a/README.md
+++ b/README.md
@@ -142,6 +142,30 @@ By default `fuseki-import-graphs` only imports public graphs, however using the
 `--private` flag will import private graphs as well.  This can help decode
 existing conversions from private to public data.
 
+# Test Instance
+
+This project includes a test.yml file that can be used for testing the fuseki
+installation outside of the complete rp-ucd-deployment.  This is also a good way
+to setup a service if you just want to query the data.
+
+One method to manage the test is with an alias as in:
+
+``` bash
+alias fdc="docker-compose -p fuseki-test -f $(pwd)/test.yml"
+```
+Then you can manage the file as in:
+
+``` bash
+fdc up -d #or
+fdc exec fuseki bash
+```
+
+This compose file should have reasonable defaults, but updates to .env (eg
+FUSEKI_VERSION=1.1.1) will update the startup.  An `.env` file is *NOT* required
+however. The fuseki_endpoint for the default is
+`http://admin:testing@fuseki:3030/` with experts and experts-dev databases.
+
+
 # Special Server Initialization
 
 By default, the server is launched like `/jena-fuseki/fuseki-server

--- a/build/local-build.sh
+++ b/build/local-build.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-TAG_NAME=1.1.1
+TAG_NAME=1.1.2
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $ROOT_DIR/..

--- a/build/submit-build.sh
+++ b/build/submit-build.sh
@@ -2,7 +2,7 @@
 
 # manually setting this... for now :(
 # TAG_NAME=jena-3.15.0-c-0.0.3
-TAG_NAME=1.1.1
+TAG_NAME=1.1.2
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $ROOT_DIR/..

--- a/configuration/experts.ttl.tmpl
+++ b/configuration/experts.ttl.tmpl
@@ -40,26 +40,13 @@ tdb2:DatasetTDB2  rdfs:subClassOf  ja:RDFDataset .
         fuseki:operation fuseki:query ;
         fuseki:name "query"
         ] ;
-#    fuseki:endpoint [
-#        fuseki:operation fuseki:update ;
-#        fuseki:name "update"
-#        ] ;
     fuseki:endpoint [
         fuseki:operation fuseki:gsp-r ;
         fuseki:name "get"
         ] ;
-#    fuseki:endpoint [
-#        fuseki:operation fuseki:gsp-rw ;
-#        fuseki:name "data"
-#        ] ;
-#    fuseki:endpoint [
-#        fuseki:operation fuseki:upload ;
-#        fuseki:name "upload"
-#        ] ;
     .
 
 :experts_private a fuseki:Service ;
-#    fuseki:name "experts_private" ;
     fuseki:dataset :dataset_private ;
     fuseki:endpoint [
         fuseki:operation fuseki:query ;
@@ -99,6 +86,7 @@ tdb2:DatasetTDB2  rdfs:subClassOf  ja:RDFDataset .
     a tdb2:GraphTDB2;
     tdb2:dataset :tdb_public;
     .
+
 
 # These are being planned to remove.
 :graph_public_iam

--- a/configuration/experts.ttl.tmpl
+++ b/configuration/experts.ttl.tmpl
@@ -85,6 +85,7 @@ tdb2:DatasetTDB2  rdfs:subClassOf  ja:RDFDataset .
 :graph_public
     a tdb2:GraphTDB2;
     tdb2:dataset :tdb_public;
+    tdb2:graphName <http://experts.ucdavis.edu/> ;
     .
 
 

--- a/fuseki-import-graphs
+++ b/fuseki-import-graphs
@@ -2,14 +2,17 @@
 
 # Reads the directories passed on the commmand line, and imports
 
-if ! opts=$(getopt -o c: --long clone: -n fuseki-import-graphs -- "$@"); then
+if ! opts=$(getopt -o pc: --long private,clone: -n fuseki-import-graphs -- "$@"); then
   echo "Bad Command Options." >&2 ; exit 1 ; fi
 
 eval set -- "$opts"
 
+private=
+
 while true; do
 	case $1 in
     -c | --clone) clone="$2"; shift 2;;
+    -p | --private) private=1; shift ;;
 	  *) shift; break;
   esac
 done
@@ -20,9 +23,15 @@ load=http://fuseki:3030/experts_private/data
 graphs=(
   iam.ucdavis.edu
   oapolicy.universityofcalifornia.edu
+  experts.ucdavis.edu
+)
+
+if [[ -n $private ]] ; then
+  graphs+=(
   experts.ucdavis.edu%2Fiam
   experts.ucdavis.edu%2Foap
-)
+  )
+fi
 
 import_dir=/fuseki/import
 

--- a/fuseki-import-graphs
+++ b/fuseki-import-graphs
@@ -58,7 +58,7 @@ for root in "$@"; do
   done
 done
 
-if [[ -d $clone_dir ]]; then
-  echo "fuseki-import-graphs - rm $clone_dir"
-  rm -rf $clone_dir
-fi
+#if [[ -d $clone_dir ]]; then
+#  echo "fuseki-import-graphs - rm $clone_dir"
+#  rm -rf $clone_dir
+#fi

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,39 @@
+#! /usr/bin/env yml-docker-compose.sh
+# This Example yml can start and external FUSKEKI instance
+
+# I use this to manage the test
+# alias fdc="docker-compose -p fuseki-test -f $(pwd)/test.yml"
+
+# Then `fdc up -d` for example.
+
+# This compose file should have reasonable defaults, but
+# updates to .env (eg FUSEKI_VERSION=foo) will update the startup
+
+# An .env file is *NOT* required however.
+# A complete .env file might look like:
+#ADMIN_PASSWORD=testing
+#JVM_ARGS=-Xmx4g
+#FUSEKI_HOST_PORT=6030
+#FUSEKI_VERSION=1.1.2
+#KAFKA_ENABLED=false
+
+# The ENDPOINT Associated w/ the default is
+#FUSEKI_ENDPOINT=http://admin:testing@fuseki:3030/
+
+version: '3.5'
+
+services:
+  fuseki:
+    image: ucdlib/rp-ucd-fuseki:${FUSEKI_VERSION:-1.1.2}
+    environment:
+      - JVM_ARGS=${JVM_ARGS:- -Xmx4g}
+      - FUSEKI_PASSWORD=${FUSEKI_PASSWORD:-testing}
+      - KAFKA_ENABLED=${KAFKA_ENABLED:-false}
+    volumes:
+      - fuseki-data:/fuseki
+    ports:
+      - ${FUSEKI_HOST_PORT:-3030}:3030
+
+volumes:
+  fuseki-data:
+    driver: local


### PR DESCRIPTION
This updates the import script so that developers can import the private graphs if they'd like to track data develoment.
